### PR TITLE
Added Music Duration Reducer

### DIFF
--- a/MODLIST.md
+++ b/MODLIST.md
@@ -45,3 +45,4 @@ Despite being a toolkit for modding functionality, Fabric API actually contains 
 | --- | --- | --- | --- | --- | --- | --- |
 | Sodium Extra Fabric (Requires Sodium) | Adds more graphical settings to Sodium, similar to OptiFine's. | FlashyReese | No | No | Canvas | https://github.com/FlashyReese/sodium-extra-fabric/ |
 | Dynamic FPS | Slows down Minecraft's rendering when Minecraft is minimized or in the background to improve performance in other applications. | juliand665 | Yes | No | None | https://github.com/juliand665/Dynamic-FPS/ |
+| Music Duration Reducer | Reduces the duration between minecraft songs and dynamically changes the song based on your environment without it suddenly shifting out. | LudoCrypt | Yes | No | None | https://github.com/LudoCrypt/Music-Duration-Reducer


### PR DESCRIPTION
Makes the minecraft music play at quicker intervals after a song ends and makes dynamic shifting between music not abrupt.